### PR TITLE
Testing patch version jump gh action

### DIFF
--- a/.github/workflows/pr-merge.yaml
+++ b/.github/workflows/pr-merge.yaml
@@ -1,0 +1,21 @@
+name: pr-merge-action
+run-name: increment package.json verion on pr merge
+on:
+  pull-request:
+    types: [closed]
+
+jobs:
+  version_bump:
+    # this job will only run if the PR has been merged
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - name: ⬇️ Checkout repo
+      uses: actions/checkout@v4
+    - name: ⏫ Bumping version
+      uses: jpb06/bump-package@latest
+      with:
+        major-keywords: BREAKING CHANGE
+        minor-keywords: feat,minor
+        patch-keywords: fix,chore
+        should-default-to-patch: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-doc-statement-constructor",
-  "version": "1.12.28",
+  "version": "1.12.29",
   "description": "Data construction for statement generation",
   "homepage": "https://github.com/DEFRA/ffc-doc-statement-constructor",
   "main": "app/index.js",


### PR DESCRIPTION
This should by default increment the package.json version number when the PR is merged.

The action will bump the package depending on commits present in the pull request when it is merged to the master branch. By priority order:

if any commit message contains BREAKING CHANGE, then there will be a major bump.
if any commit message contains feat or minor but none of the above, then there will be a minor bump.
if any commit message contains fix or chore but none of the above, then there will be a patch bump.
A tag will also be created by the action.



