### PR TITLE
update helm, upgrade liquibase with headless

### DIFF
--- a/docker-compose.migrate.yaml
+++ b/docker-compose.migrate.yaml
@@ -13,7 +13,7 @@ x-common-postgres: &common-postgres
 
 services:
   database-up:
-    image: liquibase/liquibase:3.10.x
+    image: liquibase/liquibase:4.12.0
     environment:
       <<: [*common-postgres, *common-migration]
     entrypoint: >
@@ -25,7 +25,7 @@ services:
       - ./scripts:/scripts
 
   database-down:
-    image: liquibase/liquibase:3.10.x
+    image: liquibase/liquibase:4.12.0
     environment:
       <<: [*common-postgres, *common-migration]
     entrypoint: >

--- a/helm/ffc-doc-statement-constructor/Chart.yaml
+++ b/helm/ffc-doc-statement-constructor/Chart.yaml
@@ -5,5 +5,5 @@ name: ffc-doc-statement-constructor
 version: 1.0.0
 dependencies:
 - name: ffc-helm-library
-  version: 4.7.2
+  version: 5.0.6
   repository: https://raw.githubusercontent.com/defra/ffc-helm-repository/master/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-doc-statement-constructor",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-doc-statement-constructor",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-doc-statement-constructor",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Data construction for statement generation",
   "homepage": "https://github.com/DEFRA/ffc-doc-statement-constructor",
   "main": "app/index.js",
@@ -21,9 +21,9 @@
     "Abidemi Adio abidemi.adio@defra.gov.uk",
     "Leigh Godson leigh.godson@atos.net",
     "Amirs Ismuhametovs amirs.ishmuhametovs@defra.gov.uk",
-    "Sam Plackett samuel.plackett@eviden.com",
-    "John Barnard john.barnard.external@eviden.com",
-    "Oliver Lewington oliver.lewington@eviden.com"
+    "Sam Plackett samuel.plackett@atos.net",
+    "John Barnard john.barnard.external@atos.net",
+    "Oliver Lewington oliver.lewington@atos.net"
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {

--- a/scripts/migration/database-up
+++ b/scripts/migration/database-up
@@ -2,6 +2,7 @@
 echo "db update on $POSTGRES_HOST $SCHEMA_NAME as $SCHEMA_USERNAME"
 /scripts/postgres-wait && /liquibase/liquibase \
 --driver=org.postgresql.Driver \
+--hub-mode=off \
 --changeLogFile=/changelog/db.changelog.xml \
 --url=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB \
 --username="$SCHEMA_USERNAME" --password="$SCHEMA_PASSWORD" --defaultSchemaName="$SCHEMA_NAME" \


### PR DESCRIPTION
Update Helm to 5.0.6 for NginX update
Update Liquibase to V4 
Add Headless mode to disable hub prompts